### PR TITLE
docs: fix bad naming and restore deleted Pricing2Yaml fields

### DIFF
--- a/specification/CHANGELOG.md
+++ b/specification/CHANGELOG.md
@@ -8,8 +8,10 @@
 
 ### :white_check_mark: New
 
+- new field `starts` to indicate the beginning of operation of the pricing
+- new field `ends` to indicate the ending of operation of the pricing
 - new field `createdAt` to replace `day` `month` and `year`, see this [section](#deleted)
-- now addOns can depend on addOns putting the name of the addOn in the `avaliableFor` field
+- now addOns can depend on addOns putting the name of the addOn in the `dependsOn` field
 
 ### :x: Deleted
 


### PR DESCRIPTION
- `starts` and `ends` fields were deleted in the `CHANGELOG`  by a commit c07fabddf51eb118bfb67b0dabddb6046ce2e0c1 adding them back again
- Fix bad naming when addons depends on addons it should be `dependsOn` instead of `availableFor`.