### PR TITLE
feat: add 'version' positive and negative tests

### DIFF
--- a/src/test/java/io/github/isagroup/parsing/positive/PricingManagerParserTest.java
+++ b/src/test/java/io/github/isagroup/parsing/positive/PricingManagerParserTest.java
@@ -1,23 +1,16 @@
 package io.github.isagroup.parsing.positive;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.LocalDate;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
-import io.github.isagroup.exceptions.PricingParsingException;
 import io.github.isagroup.models.Feature;
-import io.github.isagroup.models.Plan;
 import io.github.isagroup.models.PricingManager;
 import io.github.isagroup.services.updaters.Version;
 import io.github.isagroup.services.yaml.YamlUtils;
@@ -163,12 +156,33 @@ class PricingManagerParserTest {
         assertEquals(15.99, pm.getPlans().get("PRO").getPrice());
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = { "version-as-string", "version-as-float" })
-    void givenVersionShouldParse(String input) {
+    @Test
+    @DisplayName(value = "Given 'syntaxVersion' as string should parse")
+    void givenSyntaxVersionAsStringShouldParse() {
 
-        String path = String.format(TEST_CASES + "version/%s.yml", input);
-        PricingManager pricingManager = YamlUtils.retrieveManagerFromYaml(path);
-        assertInstanceOf(Version.class, pricingManager.getSyntaxVersion());
+        PricingManager pm = YamlUtils.retrieveManagerFromYaml(TEST_CASES + "syntaxVersion/syntaxVersion-as-string.yml");
+        assertEquals(Version.V2_1, pm.getSyntaxVersion());
+    }
+
+    @Test
+    @DisplayName(value = "Given 'syntaxVersion' as timestamp should parse")
+    void givenSyntaxVersionAsTimestampShouldParse() {
+        PricingManager pm = YamlUtils.retrieveManagerFromYaml(TEST_CASES + "syntaxVersion/syntaxVersion-as-float.yml");
+        assertEquals(Version.V2_1, pm.getSyntaxVersion());
+
+    }
+
+    @Test
+    @DisplayName(value = "Given no 'version', default value should be stringify timestamp of 'createdAt'")
+    void givenNullVersionShouldHaveDefaultValue() {
+        PricingManager pm = YamlUtils.retrieveManagerFromYaml(TEST_CASES + "version/version-is-null.yml");
+        assertEquals("2025-01-14", pm.getVersion());
+    }
+
+    @Test
+    @DisplayName(value = "Setting a 'version' should parse")
+    void givenAVersionShouldParse() {
+        PricingManager pm = YamlUtils.retrieveManagerFromYaml(TEST_CASES + "version/version-is-set.yml");
+        assertEquals("alpha", pm.getVersion());
     }
 }

--- a/src/test/resources/negative-parsing-tests.csv
+++ b/src/test/resources/negative-parsing-tests.csv
@@ -72,6 +72,8 @@ Throw an error if 'url' is a plain string;parsing/negative/url/invalid-string-ur
 Throw an error if 'url' is not a string;parsing/negative/url/number-url.yml;If 'url' field is used, it has to be a string
 # variables
 Throw an error if 'variables' is not a map;parsing/negative/variables/variables-is-boolean.yml;variables must be a map but found Boolean instead
+# version
+Throw an error if 'version' is not a str;parsing/negative/version/version-is-bool.yml;'version' has to be a string
 # syntaxVersion
 Throw an error if 'syntaxVersion' is bad formated;parsing/negative/syntaxVersion/pricing-invalid-format-version.yml;Invalid syntax version "1.0.0", use <major>.<minor> version format
 Throw an error if 'syntaxVersion' is not a string like <major>.<minor>;parsing/negative/syntaxVersion/pricing-invalid-type-version.yml;The syntax version field of the pricing must be a string or a double. Please ensure that the version field is present and correctly formatted

--- a/src/test/resources/parsing/negative/version/version-is-bool.yml
+++ b/src/test/resources/parsing/negative/version/version-is-bool.yml
@@ -1,10 +1,8 @@
-version: "1.1"
-saasName: Version as string
+syntaxVersion: "2.1"
+saasName: "'version' must be str"
+version: true
+createdAt: 2025-01-14
 currency: EUR
-hasAnnualPayment: false
-createdAt: "2024-08-30"
-starts: 2024-01-01 12:00:00
-ends: 2025-01-01 12:00:00
 features:
   foo:
     type: DOMAIN
@@ -13,8 +11,7 @@ features:
 plans:
   BASIC:
     description: Basic plan
-    monthlyPrice: 0.0
-    annualPrice: 0.0
+    price: 0.0
     unit: user/month
     features: null
     usageLimits: null

--- a/src/test/resources/parsing/positive/syntaxVersion/syntaxVersion-as-float.yml
+++ b/src/test/resources/parsing/positive/syntaxVersion/syntaxVersion-as-float.yml
@@ -1,0 +1,16 @@
+syntaxVersion: 2.1
+saasName: Syntax version as string
+createdAt: 2024-09-23
+currency: EUR
+features:
+  foo:
+    type: DOMAIN
+    valueType: TEXT
+    defaultValue: baz
+plans:
+  BASIC:
+    description: Basic plan
+    price: 0.0
+    unit: user/month
+    features: null
+    usageLimits: null

--- a/src/test/resources/parsing/positive/syntaxVersion/syntaxVersion-as-string.yml
+++ b/src/test/resources/parsing/positive/syntaxVersion/syntaxVersion-as-string.yml
@@ -1,0 +1,16 @@
+syntaxVersion: "2.1"
+saasName: Syntax version as string
+createdAt: 2024-09-23
+currency: EUR
+features:
+  foo:
+    type: DOMAIN
+    valueType: TEXT
+    defaultValue: baz
+plans:
+  BASIC:
+    description: Basic plan
+    price: 0.0
+    unit: user/month
+    features: null
+    usageLimits: null

--- a/src/test/resources/parsing/positive/version/version-is-null.yml
+++ b/src/test/resources/parsing/positive/version/version-is-null.yml
@@ -1,0 +1,16 @@
+syntaxVersion: "2.1"
+saasName: Testing 'version' default value
+createdAt: 2025-01-14
+currency: EUR
+features:
+  foo:
+    type: DOMAIN
+    valueType: TEXT
+    defaultValue: baz
+plans:
+  BASIC:
+    description: Basic plan
+    price: 0.0
+    unit: user/month
+    features: null
+    usageLimits: null

--- a/src/test/resources/parsing/positive/version/version-is-set.yml
+++ b/src/test/resources/parsing/positive/version/version-is-set.yml
@@ -1,8 +1,8 @@
-version: 1.1
-saasName: version as float is also supported
-createdAt: 2024-09-23
+syntaxVersion: "2.1"
+saasName: Testing 'version' default value
+version: alpha
+createdAt: 2025-01-14
 currency: EUR
-hasAnnualPayment: false
 features:
   foo:
     type: DOMAIN
@@ -11,8 +11,7 @@ features:
 plans:
   BASIC:
     description: Basic plan
-    monthlyPrice: 0.0
-    annualPrice: 0.0
+    price: 0.0
     unit: user/month
     features: null
     usageLimits: null


### PR DESCRIPTION
Add positive and negative tests for field 'version'.

@Alex-GF in docs page says its default value is `latest` but in the current implementation, its default value is `createdAt` stringified