### PR TITLE
Clean duplicated code in all updaters

### DIFF
--- a/src/main/java/io/github/isagroup/services/updaters/V11ToV20Updater.java
+++ b/src/main/java/io/github/isagroup/services/updaters/V11ToV20Updater.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Map;
 
 import io.github.isagroup.exceptions.UpdateException;
-import io.github.isagroup.exceptions.VersionException;
 
 public class V11ToV20Updater extends VersionUpdater {
 
@@ -16,14 +15,7 @@ public class V11ToV20Updater extends VersionUpdater {
     @Override
     public void update(Map<String, Object> configFile) throws UpdateException {
 
-        try {
-            if (Version.version(configFile.get("version")).compare(this.getSource()) < 0) {
-                super.update(configFile);
-
-            }
-        } catch (VersionException e) {
-            throw new UpdateException(e.getMessage(), configFile);
-        }
+        super.update(configFile);
 
         updateContainersWithOnlyOnePriceField(configFile);
         removeHasAnnualPaymentField(configFile);

--- a/src/main/java/io/github/isagroup/services/updaters/V20ToV21Updater.java
+++ b/src/main/java/io/github/isagroup/services/updaters/V20ToV21Updater.java
@@ -3,7 +3,6 @@ package io.github.isagroup.services.updaters;
 import java.util.Map;
 
 import io.github.isagroup.exceptions.UpdateException;
-import io.github.isagroup.exceptions.VersionException;
 
 public class V20ToV21Updater extends VersionUpdater {
 
@@ -14,15 +13,7 @@ public class V20ToV21Updater extends VersionUpdater {
     @Override
     public void update(Map<String, Object> configFile) throws UpdateException {
 
-        try {
-            if (Version.version(configFile.get("version")).compare(this.getSource()) < 0) {
-                super.update(configFile);
-
-            }
-        } catch (VersionException e) {
-            throw new UpdateException(e.getMessage(), configFile);
-        }
-
+        super.update(configFile);
         refactorPricingVersion(configFile);
     }
 

--- a/src/main/java/io/github/isagroup/services/updaters/Version.java
+++ b/src/main/java/io/github/isagroup/services/updaters/Version.java
@@ -138,6 +138,10 @@ public enum Version {
         return 0;
     }
 
+    public boolean lessThan(Version version) {
+        return this.compare(version) < 0;
+    }
+
     @Override
     public String toString() {
         return this.major + "." + this.minor;

--- a/src/main/java/io/github/isagroup/services/updaters/VersionUpdater.java
+++ b/src/main/java/io/github/isagroup/services/updaters/VersionUpdater.java
@@ -21,10 +21,19 @@ public abstract class VersionUpdater implements Updater {
             return;
         }
 
-        this.versionUpdater.update(configFile);
+        Object version = configFile.getOrDefault("syntaxVersion", configFile.get("version"));
+
+        if (isSpecOutdated(version)) {
+            this.versionUpdater.update(configFile);
+        }
+
     }
 
     public Version getSource() {
         return source;
+    }
+
+    public boolean isSpecOutdated(Object version) {
+        return Version.version(version).lessThan(this.getSource());
     }
 }


### PR DESCRIPTION
Now `VersionUpdater.java` knows when to update the spec, that way we can stop duplicating code in decorators. This refactor is pretty useful for contributors, they have to do less steps.